### PR TITLE
🐛 Correctly retrieve matched collection when multiple collections

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -124,7 +124,7 @@ class StarToRaindropExtension extends Minz_Extension {
 
       Minz_Log::debug('Collection found: ' . json_encode($filtered_collections));
 
-      $collection_obj = $filtered_collections[0];
+      $collection_obj = array_values($filtered_collections)[0];
 
       $collection = array(
         "\$ref" => "collections",


### PR DESCRIPTION
A filtered array no longer encodes to json arrays, as the indices are no longer continuous. For this reason, it is necessary to use array_values to ensure the first element is present at the 0th index.

See discussion in comments here https://www.php.net/manual/en/function.array-filter.php.

Reporter: BraedonGood